### PR TITLE
Error in stream support

### DIFF
--- a/nameko_grpc_opentelemetry/__init__.py
+++ b/nameko_grpc_opentelemetry/__init__.py
@@ -81,13 +81,11 @@ class GrpcEntrypointAdapter(EntrypointAdapter):
                 # result is tee'd in handle_result because the service
                 # has already drained the iterator by the time we get here
                 try:
-                    for res in result_iterators.pop(worker_ctx, {}):
-                        if res is not None:
-                            messages.append(
-                                serialise_to_string(
-                                    scrub(MessageToDict(res), self.config)
-                                )
-                            )
+                    messages.extend(
+                        serialise_to_string(scrub(MessageToDict(res), self.config))
+                        for res in result_iterators.pop(worker_ctx, {})
+                        if res is not None
+                    )
                 except Exception as exc:
                     messages.append(f"{type(exc).__name__}: {exc}")
 

--- a/nameko_grpc_opentelemetry/__init__.py
+++ b/nameko_grpc_opentelemetry/__init__.py
@@ -91,6 +91,15 @@ class GrpcEntrypointAdapter(EntrypointAdapter):
                             )
                 except Exception as exc:
                     messages.append(f"{type(exc).__name__}: {exc}")
+
+                    # no way to access span -- see xfail tests
+                    # exc_info = sys.exc_info()
+                    # span.record_exception(
+                    #     exc_info[1],
+                    #     escaped=True,
+                    #     attributes=self.get_exception_attributes(worker_ctx, exc_info),
+                    # )
+
                 response_string = " | ".join(messages)
 
             else:

--- a/nameko_grpc_opentelemetry/tee.py
+++ b/nameko_grpc_opentelemetry/tee.py
@@ -76,4 +76,4 @@ class Teeable:
 
     def tee(self):
         self.iterable, safe_tee = safetee(self.iterable, 2)
-        return safe_tee
+        return Teeable(safe_tee)

--- a/tests/example.proto
+++ b/tests/example.proto
@@ -12,6 +12,8 @@ service example {
   rpc unary_grpc_error (ExampleRequest) returns (ExampleReply) {}
   rpc unary_error_via_context (ExampleRequest) returns (ExampleReply) {}
   rpc stream_error (ExampleRequest) returns (stream ExampleReply) {}
+  rpc stream_grpc_error (ExampleRequest) returns (stream ExampleReply) {}
+  rpc stream_error_via_context (ExampleRequest) returns (stream ExampleReply) {}
   rpc sensitive (SensitiveRequest) returns (SensitiveReply) {}
 }
 

--- a/tests/test_grpc.py
+++ b/tests/test_grpc.py
@@ -539,7 +539,7 @@ class TestResultAttributes:
             @grpc
             def stream_error(self, request, context):
                 message = request.value * (request.multiplier or 1)
-                for i in range(request.response_count):
+                for i in range(request.response_count):  # pragma: no cover
                     # raise on the last message
                     if i == request.response_count - 1:
                         raise Error("boom")
@@ -729,7 +729,7 @@ class TestExceptions:
             @grpc
             def stream_error(self, request, context):
                 message = request.value * (request.multiplier or 1)
-                for i in range(request.response_count):
+                for i in range(request.response_count):  # pragma: no cover
                     # raise on the last message
                     if i == request.response_count - 1:
                         raise Error("boom")
@@ -738,7 +738,7 @@ class TestExceptions:
             @grpc
             def stream_error_via_context(self, request, context):
                 message = request.value * (request.multiplier or 1)
-                for i in range(request.response_count):
+                for i in range(request.response_count):  # pragma: no cover
                     # break on the last message
                     if i == request.response_count - 1:
 
@@ -761,7 +761,7 @@ class TestExceptions:
             @grpc
             def stream_grpc_error(self, request, context):
                 message = request.value * (request.multiplier or 1)
-                for i in range(request.response_count):
+                for i in range(request.response_count):  # pragma: no cover
                     # raise on the last message
                     if i == request.response_count - 1:
 
@@ -1084,7 +1084,7 @@ class TestServerStatus:
             @grpc
             def stream_error(self, request, context):
                 message = request.value * (request.multiplier or 1)
-                for i in range(request.response_count):
+                for i in range(request.response_count):  # pragma: no cover
                     # raise on the last message
                     if i == request.response_count - 1:
                         raise Error("boom")
@@ -1093,7 +1093,7 @@ class TestServerStatus:
             @grpc
             def stream_error_via_context(self, request, context):
                 message = request.value * (request.multiplier or 1)
-                for i in range(request.response_count):
+                for i in range(request.response_count):  # pragma: no cover
                     # break on the last message
                     if i == request.response_count - 1:
 

--- a/tests/test_tee.py
+++ b/tests/test_tee.py
@@ -93,6 +93,18 @@ class TestTeeable:
         assert next(tee2) == 0
         assert next(tee2) == 1
 
+    def test_tee_is_teeable(self, make_generator):
+        gen = Teeable(make_generator())
+        tee1 = gen.tee()
+        tee2 = tee1.tee()
+
+        assert next(gen) == 0
+        assert next(gen) == 1
+        assert next(tee1) == 0
+        assert next(tee1) == 1
+        assert next(tee2) == 0
+        assert next(tee2) == 1
+
     def test_thread_safe(self, make_generator, tracker):
 
         gen = Teeable(make_generator())


### PR DESCRIPTION
This PR fixes a bug wherein the `send_response_payloads` feature would consume the response iterator if the stream ended with an exception, and ensures that the `rpc.grpc.status_code` attribute and opentelemetry status are appropriately set in this scenario.

It also ensures that the `rpc.grpc.status_code` attribute and opentelemetry status are appropriately set when an error response is returned via the `context` object rather than by raising an exception, in both unary and streaming  responses.