### PR TITLE
Truncate request and response payloads to avoid sending too much data

### DIFF
--- a/nameko_grpc_opentelemetry/__init__.py
+++ b/nameko_grpc_opentelemetry/__init__.py
@@ -15,7 +15,7 @@ from nameko_grpc.inspection import Inspector
 from nameko_opentelemetry import active_tracer
 from nameko_opentelemetry.entrypoints import EntrypointAdapter
 from nameko_opentelemetry.scrubbers import scrub
-from nameko_opentelemetry.utils import serialise_to_string
+from nameko_opentelemetry.utils import serialise_to_string, truncate
 from opentelemetry import trace
 from opentelemetry.instrumentation.instrumentor import BaseInstrumentor
 from opentelemetry.instrumentation.utils import unwrap
@@ -69,7 +69,15 @@ class GrpcEntrypointAdapter(EntrypointAdapter):
                     scrub(MessageToDict(request), self.config)
                 )
 
-            return {"rpc.grpc.request": request_string}
+            request_truncated, truncated = truncate(
+                request_string,
+                max_len=self.config.get("truncate_max_length"),
+            )
+
+            return {
+                "rpc.grpc.request": request_truncated,
+                "rpc.grpc.request_truncated": str(truncated),
+            }
 
     def get_result_attributes(self, worker_ctx, result):
         attributes = {}
@@ -100,7 +108,15 @@ class GrpcEntrypointAdapter(EntrypointAdapter):
                 else:
                     response_string = ""
 
-            attributes.update({"rpc.grpc.response": response_string})
+            response_truncated, truncated = truncate(
+                response_string,
+                max_len=self.config.get("truncate_max_length"),
+            )
+
+            attributes.update({
+                "rpc.grpc.response": response_truncated,
+                "rpc.grpc.response_truncated": str(truncated),
+            })
 
         return attributes
 

--- a/nameko_grpc_opentelemetry/__init__.py
+++ b/nameko_grpc_opentelemetry/__init__.py
@@ -113,10 +113,12 @@ class GrpcEntrypointAdapter(EntrypointAdapter):
                 max_len=self.config.get("truncate_max_length"),
             )
 
-            attributes.update({
-                "rpc.grpc.response": response_truncated,
-                "rpc.grpc.response_truncated": str(truncated),
-            })
+            attributes.update(
+                {
+                    "rpc.grpc.response": response_truncated,
+                    "rpc.grpc.response_truncated": str(truncated),
+                }
+            )
 
         return attributes
 

--- a/tests/test_grpc.py
+++ b/tests/test_grpc.py
@@ -533,7 +533,7 @@ class TestCallArgsAttributes:
 
         with entrypoint_waiter(container, "stream_unary"):
             response = client.stream_unary(generate_requests())
-            assert len(response.message) == 389
+            assert len(response.message.split(',')) == 100
 
         spans = memory_exporter.get_finished_spans()
         assert len(spans) == 2

--- a/tests/test_grpc.py
+++ b/tests/test_grpc.py
@@ -483,9 +483,7 @@ class TestCallArgsAttributes:
         self, protos, client, container, memory_exporter, send_request_payloads
     ):
         with entrypoint_waiter(container, "unary_unary"):
-            response = client.unary_unary(
-                protos.ExampleRequest(value="A"*100)
-            )
+            response = client.unary_unary(protos.ExampleRequest(value="A" * 100))
             assert len(response.message) == 100
 
         spans = memory_exporter.get_finished_spans()
@@ -533,7 +531,7 @@ class TestCallArgsAttributes:
 
         with entrypoint_waiter(container, "stream_unary"):
             response = client.stream_unary(generate_requests())
-            assert len(response.message.split(',')) == 100
+            assert len(response.message.split(",")) == 100
 
         spans = memory_exporter.get_finished_spans()
         assert len(spans) == 2

--- a/tests/test_grpc.py
+++ b/tests/test_grpc.py
@@ -411,6 +411,8 @@ class TestCallArgsAttributes:
     def config(self, config, send_request_payloads):
         # disable request payloads based on param
         config["send_request_payloads"] = send_request_payloads
+        # override default truncation length
+        config["truncate_max_length"] = 200
         return config
 
     @pytest.fixture
@@ -472,8 +474,30 @@ class TestCallArgsAttributes:
 
         if send_request_payloads:
             assert attributes["rpc.grpc.request"] == "{'value': 'A'}"
+            assert attributes["rpc.grpc.request_truncated"] == "False"
         else:
             assert "rpc.grpc.request" not in attributes
+            assert "rpc.grpc.request_truncated" not in attributes
+
+    def test_unary_request_truncated(
+        self, protos, client, container, memory_exporter, send_request_payloads
+    ):
+        with entrypoint_waiter(container, "unary_unary"):
+            response = client.unary_unary(
+                protos.ExampleRequest(value="A", multiplier=1000)
+            )
+            assert len(response.message) >= 1000
+
+        spans = memory_exporter.get_finished_spans()
+        assert len(spans) == 2
+
+        server_span = list(filter(lambda span: span.kind == SpanKind.SERVER, spans))[0]
+
+        attributes = server_span.attributes
+
+        if send_request_payloads:
+            assert len(attributes["rpc.grpc.request"]) == 200
+            assert attributes["rpc.grpc.request_truncated"] == "True"
 
     def test_streaming_request(
         self, protos, client, container, memory_exporter, send_request_payloads
@@ -495,8 +519,32 @@ class TestCallArgsAttributes:
 
         if send_request_payloads:
             assert attributes["rpc.grpc.request"] == "{'value': 'A'} | {'value': 'B'}"
+            assert attributes["rpc.grpc.request_truncated"] == "False"
         else:
             assert "rpc.grpc.request" not in attributes
+            assert "rpc.grpc.request_truncated" not in attributes
+
+    def test_streaming_request_truncated(
+        self, protos, client, container, memory_exporter, send_request_payloads
+    ):
+        def generate_requests():
+            for index, value in enumerate(["A"] * 1000):
+                yield protos.ExampleRequest(value=value + str(index))
+
+        with entrypoint_waiter(container, "stream_unary"):
+            response = client.stream_unary(generate_requests())
+            assert len(response.message) == 2000
+
+        spans = memory_exporter.get_finished_spans()
+        assert len(spans) == 2
+
+        server_span = list(filter(lambda span: span.kind == SpanKind.SERVER, spans))[0]
+
+        attributes = server_span.attributes
+
+        if send_request_payloads:
+            assert len(attributes["rpc.grpc.request"]) == 200
+            assert attributes["rpc.grpc.request_truncated"] == "True"
 
     def test_different_argument_name(
         self, protos, client, container, memory_exporter, send_request_payloads
@@ -522,6 +570,7 @@ class TestCallArgsAttributes:
             )
         else:
             assert "rpc.grpc.request" not in attributes
+            assert "rpc.grpc.request_truncated" not in attributes
 
 
 class TestResultAttributes:
@@ -535,6 +584,8 @@ class TestResultAttributes:
     def config(self, config, send_response_payloads):
         # disable request payloads based on param
         config["send_response_payloads"] = send_response_payloads
+        # override default truncation length
+        config["truncate_max_length"] = 200
         return config
 
     @pytest.fixture
@@ -598,8 +649,31 @@ class TestResultAttributes:
         attributes = server_span.attributes
         if send_response_payloads:
             assert attributes["rpc.grpc.response"] == "{'message': 'A'}"
+            assert attributes["rpc.grpc.response_truncated"] == "False"
         else:
             assert "rpc.grpc.response" not in attributes
+            assert "rpc.grpc.response_truncated" not in attributes
+
+    def test_unary_response_truncated(
+        self, container, client, protos, memory_exporter, send_response_payloads
+    ):
+        multiplier = 1000
+        with entrypoint_waiter(container, "unary_unary"):
+            response = client.unary_unary(
+                protos.ExampleRequest(value="A", multiplier=multiplier)
+            )
+            assert response.message == "A" * multiplier
+
+        spans = memory_exporter.get_finished_spans()
+        assert len(spans) == 2
+
+        server_span = list(filter(lambda span: span.kind == SpanKind.SERVER, spans))[0]
+
+        attributes = server_span.attributes
+
+        if send_response_payloads:
+            assert len(attributes["rpc.grpc.response"]) == 200
+            assert attributes["rpc.grpc.response_truncated"] == "True"
 
     def test_stream_response(
         self, container, client, protos, memory_exporter, send_response_payloads
@@ -625,8 +699,33 @@ class TestResultAttributes:
                 attributes["rpc.grpc.response"]
                 == "{'message': 'A', 'seqno': 1} | {'message': 'A', 'seqno': 2}"
             )
+            assert attributes["rpc.grpc.response_truncated"] == "False"
         else:
             assert "rpc.grpc.response" not in attributes
+            assert "rpc.grpc.response_truncated" not in attributes
+
+    def test_stream_response_truncated(
+        self, container, client, protos, memory_exporter, send_response_payloads
+    ):
+        with entrypoint_waiter(container, "unary_stream"):
+            responses = client.unary_stream(
+                protos.ExampleRequest(value="A", response_count=100)
+            )
+            assert (
+                len([(response.message, response.seqno) for response in responses])
+                == 100
+            )
+
+        spans = memory_exporter.get_finished_spans()
+        assert len(spans) == 2
+
+        server_span = list(filter(lambda span: span.kind == SpanKind.SERVER, spans))[0]
+
+        attributes = server_span.attributes
+
+        if send_response_payloads:
+            assert len(attributes["rpc.grpc.response"]) == 200
+            assert attributes["rpc.grpc.response_truncated"] == "True"
 
     def test_error_in_stream(
         self, container, client, protos, memory_exporter, send_response_payloads
@@ -650,8 +749,10 @@ class TestResultAttributes:
                 attributes["rpc.grpc.response"]
                 == "{'message': 'A', 'seqno': 1} | Error: boom"
             )
+            assert attributes["rpc.grpc.response_truncated"] == "False"
         else:
             assert "rpc.grpc.response" not in attributes
+            assert "rpc.grpc.response_truncated" not in attributes
 
 
 class TestNoTracer:


### PR DESCRIPTION
Request and response payloads can get very big, so we truncate them before adding them as attributes of an event. This will ensure we don't hit the event size limit, which would cause the event from being rejected, and traces having missing spans.
